### PR TITLE
Fixed issue when allowClear didn't set the value to null

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -523,6 +523,10 @@ var Select2Component = Ember.Component.extend({
       value = data;
     }
 
+    if (Ember.isEmpty(value)) {
+      value = null;
+    }
+
     this.set("value", value);
     Ember.run.schedule('actions', this, function() {
       this.sendAction('didSelect', value, this);


### PR DESCRIPTION
When clicking the clear button the Ember value wasn't set to null. I
think this only happened when an optionValuePath was set. This fixes #112
